### PR TITLE
add wrapper around value struct in resolutions and rustfmt

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -1,53 +1,52 @@
-extern crate serde_derive;
 extern crate serde;
+extern crate serde_derive;
 extern crate serde_json;
 
-use self::serde_derive::{Serialize, Deserialize};
-use std::convert::From;
+use self::serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::convert::From;
 
 /// Request struct corresponding to the [Alexa spec](https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html#request-body-parameters)
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Request {
-	version: String,
-	session: Option<Session>,
+    version: String,
+    session: Option<Session>,
     #[serde(rename = "request")]
-	body: ReqBody,
-	context: Context
+    body: ReqBody,
+    context: Context,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Session {
     new: bool,
     #[serde(rename = "sessionId")]
     session_id: String,
-    attributes: Option<HashMap<String,String>>,
+    attributes: Option<HashMap<String, String>>,
     application: Application,
     user: User,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Application {
     #[serde(rename = "applicationId")]
-    application_id: String
+    application_id: String,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct User {
     #[serde(rename = "userId")]
     user_id: String,
     #[serde(rename = "accessToken")]
-    access_token: Option<String>
+    access_token: Option<String>,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Device {
     #[serde(rename = "deviceId")]
-    device_id: String
+    device_id: String,
 }
 
-
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ReqBody {
     #[serde(rename = "type")]
     reqtype: String,
@@ -58,10 +57,10 @@ pub struct ReqBody {
     intent: Option<Intent>,
     reason: Option<String>,
     #[serde(rename = "dialogState")]
-    dialog_state: Option<String>
+    dialog_state: Option<String>,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Context {
     #[serde(rename = "System")]
     system: System,
@@ -69,68 +68,70 @@ pub struct Context {
     audio_player: Option<AudioPlayer>,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct System {
     #[serde(rename = "apiAccessToken")]
     api_access_token: String,
     device: Option<Device>,
-    application: Option<Application>
+    application: Option<Application>,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AudioPlayer {
     token: String,
     #[serde(rename = "offsetInMilliseconds")]
     offset_in_milliseconds: u64,
     #[serde(rename = "playerActivity")]
-    player_activity: String
+    player_activity: String,
 }
 
-
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Intent {
     name: String,
     #[serde(rename = "confirmationStatus")]
     confirmation_status: String,
-    slots: Option<HashMap<String,Slot>>
+    slots: Option<HashMap<String, Slot>>,
 }
 
 impl Intent {
     fn get_slot(&self, name: &str) -> Option<&Slot> {
-        self.slots.as_ref()?
-            .get(name)
+        self.slots.as_ref()?.get(name)
     }
 }
 
-
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Slot {
     name: String,
     value: String,
     #[serde(rename = "confirmationStatus")]
     confirmation_status: String,
-    resolutions: Option<Resolution>
+    resolutions: Option<Resolution>,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Resolution {
     #[serde(rename = "resolutionsPerAuthority")]
-    resolutions_per_authority: Vec<ResolutionsPerAuthority>
+    resolutions_per_authority: Vec<ResolutionsPerAuthority>,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ResolutionsPerAuthority {
     authority: String,
     status: Status,
-    values: Vec<Value>
+    values: Vec<ValueWrapper>,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Status {
-    code: String
+    code: String,
 }
 
-#[derive(Serialize,Deserialize,Debug,Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ValueWrapper {
+    value: Value,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Value {
     name: String,
     id: String,
@@ -138,7 +139,7 @@ pub struct Value {
 
 /// Enumeration of Alexa intent types
 /// Custom intents will be User enum values discrimiated by the `String` value
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum IntentType {
     None,
     Help,
@@ -158,21 +159,21 @@ pub enum IntentType {
     StartOver,
     Stop,
     Yes,
-    User(String)
+    User(String),
 }
 
 /// Alexa standard locales
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Locale {
-	Italian,
-	German,
-	AustralianEnglish,
-	CanadianEnglish,
+    Italian,
+    German,
+    AustralianEnglish,
+    CanadianEnglish,
     BritishEnglish,
     IndianEnglish,
     AmericanEnglish,
-	Japanese,
-    Unknown
+    Japanese,
+    Unknown,
 }
 
 impl Locale {
@@ -184,7 +185,7 @@ impl Locale {
             Locale::CanadianEnglish => true,
             Locale::BritishEnglish => true,
             Locale::IndianEnglish => true,
-            _ => false
+            _ => false,
         }
     }
 }
@@ -192,7 +193,7 @@ impl Locale {
 impl<'a> From<&'a str> for Locale {
     fn from(s: &'a str) -> Locale {
         match s {
-    	    "it-IT" => Locale::Italian,
+            "it-IT" => Locale::Italian,
             "de-DE" => Locale::German,
             "en-AU" => Locale::AustralianEnglish,
             "en-CA" => Locale::CanadianEnglish,
@@ -200,19 +201,18 @@ impl<'a> From<&'a str> for Locale {
             "en-IN" => Locale::IndianEnglish,
             "en-US" => Locale::AmericanEnglish,
             "ja-JP" => Locale::Japanese,
-            _       => Locale::Unknown
+            _ => Locale::Unknown,
         }
     }
 }
 
 impl From<String> for Locale {
-    fn from (s: String) -> Locale {
+    fn from(s: String) -> Locale {
         Locale::from(s.as_str())
     }
 }
 
 impl Request {
-
     /// Extracts the locale from the request
     pub fn locale(&self) -> Locale {
         Locale::from(&*self.body.locale)
@@ -239,7 +239,7 @@ impl Request {
                 "AMAZON.StartOverIntent" => IntentType::StartOver,
                 "AMAZON.StopIntent" => IntentType::Stop,
                 "AMAZON.YesIntent" => IntentType::Yes,
-                _ => IntentType::User(i.name.clone())
+                _ => IntentType::User(i.name.clone()),
             }
         } else {
             IntentType::None
@@ -249,17 +249,19 @@ impl Request {
     /// retrieves the string value of named slot from the request, if it exists
     pub fn slot_value(&self, slot: &str) -> Option<String> {
         Some(
-            self.body.intent.as_ref()?
-                .get_slot(slot).as_ref()?
-                .value.clone()
-            )
+            self.body
+                .intent
+                .as_ref()?
+                .get_slot(slot)
+                .as_ref()?
+                .value
+                .clone(),
+        )
     }
 
     /// retrieves the attribute value with the given key, if it exists
     pub fn attribute_value(&self, key: &str) -> Option<&String> {
-        self.session.as_ref()?
-            .attributes.as_ref()?
-            .get(key)
+        self.session.as_ref()?.attributes.as_ref()?.get(key)
     }
 }
 
@@ -269,77 +271,76 @@ mod tests {
 
     #[test]
     fn test_version() {
-        let p: Result<Request,serde_json::Error> = self::serde_json::from_str(default_req());
+        let p: Result<Request, serde_json::Error> = self::serde_json::from_str(default_req());
         match p {
             Ok(req) => assert_eq!(req.version, "1.0"),
-            Err(e) => panic!(e.to_string())
+            Err(e) => panic!(e.to_string()),
         }
     }
 
     #[test]
     fn test_locale() {
-        let p: Result<Request,serde_json::Error> = self::serde_json::from_str(default_req());
+        let p: Result<Request, serde_json::Error> = self::serde_json::from_str(default_req());
         match p {
             Ok(req) => assert_eq!(req.locale(), Locale::AmericanEnglish),
-            Err(e) => panic!(e.to_string())
+            Err(e) => panic!(e.to_string()),
         }
- 
     }
 
     #[test]
     fn test_is_english() {
-        let p: Result<Request,serde_json::Error> = self::serde_json::from_str(default_req());
+        let p: Result<Request, serde_json::Error> = self::serde_json::from_str(default_req());
         match p {
             Ok(req) => assert!(req.locale().is_english()),
-            Err(e) => panic!(e.to_string())
+            Err(e) => panic!(e.to_string()),
         }
- 
     }
 
     #[test]
     fn test_intent() {
-        let p: Result<Request,serde_json::Error> = self::serde_json::from_str(default_req());
+        let p: Result<Request, serde_json::Error> = self::serde_json::from_str(default_req());
         match p {
-            Ok(req) => assert_eq!(req.intent(),IntentType::User(String::from("hello"))),
-            Err(e) => panic!(e.to_string())
+            Ok(req) => assert_eq!(req.intent(), IntentType::User(String::from("hello"))),
+            Err(e) => panic!(e.to_string()),
         }
- 
     }
 
     #[test]
     fn test_slot() {
-        let p: Result<Request,serde_json::Error> = self::serde_json::from_str(req_with_slots());
+        let p: Result<Request, serde_json::Error> = self::serde_json::from_str(req_with_slots());
         match p {
             Ok(req) => assert_eq!(req.slot_value("name"), Some(String::from("bob"))),
-            Err(e) => panic!(e.to_string())
+            Err(e) => panic!(e.to_string()),
         }
     }
 
     #[test]
     fn test_attribute() {
-        let p: Result<Request,serde_json::Error> = self::serde_json::from_str(default_req());
+        let p: Result<Request, serde_json::Error> = self::serde_json::from_str(default_req());
         match p {
             Ok(req) => {
                 assert!(req.session.is_some());
                 assert!(req.session.unwrap().attributes.is_some());
-            },
-            Err(e) => panic!(e.to_string())
+            }
+            Err(e) => panic!(e.to_string()),
         }
- 
     }
 
     #[test]
     fn test_attribute_val() {
-        let p: Result<Request,serde_json::Error> = self::serde_json::from_str(default_req());
+        let p: Result<Request, serde_json::Error> = self::serde_json::from_str(default_req());
         match p {
-            Ok(req) => assert_eq!(req.attribute_value("lastSpeech"), Some(&String::from("Jupiter has the shortest day of all the planets"))),
-            Err(e) => panic!(e.to_string())
+            Ok(req) => assert_eq!(
+                req.attribute_value("lastSpeech"),
+                Some(&String::from(
+                    "Jupiter has the shortest day of all the planets"
+                ))
+            ),
+            Err(e) => panic!(e.to_string()),
         }
- 
     }
 
-
-    fn default_req () -> &'static str {
+    fn default_req() -> &'static str {
         r#"{
 	"version": "1.0",
 	"session": {


### PR DESCRIPTION
alexa_rust was expecting the `ResolutionsPerAuthority.values` to be a vector of `Value`s. I found that what the alexa service was sending to my skill was actually:
```
"values": [
              {
                "value": {
                  "id": "f710f0615b6d5a6914ca1ba3a001973f",
                  "name": "milliliters"
                }
              }
            ]
```
This caused deserialization to fail because serde was looking for a `name` field one level higher than it is.

So I added a little value wrapper to fix the deserialization.

Also ran `rustfmt` to normalize whitespace, etc. 