### PR TITLE
Fix typo in the AskForPermissionsConsent card name

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -189,7 +189,7 @@ impl fmt::Display for CardType {
             CardType::Simple => "Simple",
             CardType::Standard => "Standard",
             CardType::LinkAccount => "LinkAccount",
-            CardType::AskForPermission => "AskForPermissonConsent",
+            CardType::AskForPermission => "AskForPermissionsConsent",
         };
         write!(f, "{}", s)
     }


### PR DESCRIPTION
As documented [here](https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html#card-object), the correct name of the card is "AskForPermissionsConsent."